### PR TITLE
Support latest homebrew and display no device error

### DIFF
--- a/scripts/list_devices.sh
+++ b/scripts/list_devices.sh
@@ -7,4 +7,14 @@ export PATH=${PATH}:${ANDROID_SDK_HOME}/platform-tools
 # adb kill-server
 # adb start-server
 
-adb devices | grep -w 'device' | cut -f1 | xargs -I X sh -c 'c=$(adb -s X shell getprop ro.product.manufacturer);m=$(adb -s X shell getprop ro.product.model);s=$(echo X);echo "$s ($c $m)"'
+# Get device list with manufacturer and model info
+device_list=$(adb devices | grep -w 'device' | cut -f1 | xargs -I X sh -c 'c=$(adb -s X shell getprop ro.product.manufacturer); m=$(adb -s X shell getprop ro.product.model); s=$(echo X); echo "$s ($c $m)"')
+
+# Check if device_list is empty
+if [ -z "$device_list" ]; then
+  # Show an Automator dialog for no devices found and exit
+  osascript -e 'display dialog "No devices found. Please connect an Android device and try again." buttons {"Exit"} default button "Exit"' >/dev/null 2>&1
+else
+  # Pass device list to the next step
+  echo "$device_list"
+fi

--- a/scripts/list_devices.sh
+++ b/scripts/list_devices.sh
@@ -8,7 +8,8 @@ export PATH=${PATH}:${ANDROID_SDK_HOME}/platform-tools
 # adb start-server
 
 # Get device list with manufacturer and model info
-device_list=$(adb devices | grep -w 'device' | cut -f1 | xargs -I X sh -c 'c=$(adb -s X shell getprop ro.product.manufacturer); m=$(adb -s X shell getprop ro.product.model); s=$(echo X); echo "$s ($c $m)"')
+device_list=$(adb devices | grep -w 'device' | cut -f1 | xargs -I X sh -c \
+  'c=$(adb -s X shell getprop ro.product.manufacturer); m=$(adb -s X shell getprop ro.product.model); s=$(echo X); echo "$s ($c $m)"')
 
 # Check if device_list is empty
 if [ -z "$device_list" ]; then

--- a/scripts/run_scrcpy.sh
+++ b/scripts/run_scrcpy.sh
@@ -3,7 +3,7 @@
 export ANDROID_SDK_HOME=~/Library/Android/sdk
 export PATH=${PATH}:${ANDROID_SDK_HOME}/platform-tools
 # Path of scrcpy
-export PATH=${PATH}:/usr/local/bin/
+export PATH=${PATH}:/usr/local/bin/:/opt/homebrew/bin/
 
 if [[ "$1" == "false" ]]
 then

--- a/scripts/select_device.applescript
+++ b/scripts/select_device.applescript
@@ -1,4 +1,7 @@
 on run {input, parameters}
+	if (count of input) is 0 then
+		return "false"
+	end if
 	if (count of input) is 1 then
 		return input
 	end if
@@ -8,6 +11,6 @@ on run {input, parameters}
 	if answer is not false then
 		return answer
 	end if
-	
+
 	return "false"
 end run


### PR DESCRIPTION
### Fixes
- Add a dialog when no device found
- Skip apple script to avoid automator failure on no input
- Add alternative path for homebrew installation

### Verified
Apple silicon
MacOS: 14.5 (23F79)
Homebrew 4.4.2
scrcpy 2.7
